### PR TITLE
encrypt function renamed to encryptMethod in C code to avoid previus …

### DIFF
--- a/encrypt_src/NativeExtension.cc
+++ b/encrypt_src/NativeExtension.cc
@@ -3,7 +3,7 @@
 using v8::FunctionTemplate;
 
 NAN_MODULE_INIT(InitAll) {
-    Nan::Set(target, Nan::New("encrypt").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(encrypt)).ToLocalChecked());
+    Nan::Set(target, Nan::New("encrypt").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(encryptMethod)).ToLocalChecked());
 }
 
 NODE_MODULE(NativeExtension, InitAll)

--- a/encrypt_src/encrypt.c
+++ b/encrypt_src/encrypt.c
@@ -14168,7 +14168,7 @@ void sub_9E9D8(unsigned char *input, unsigned char*output)
 	memcpy(output, temp2, 0x100);
 }
 
-int encrypt(const unsigned char *input, size_t input_size,
+int encryptMethod(const unsigned char *input, size_t input_size,
 	const unsigned char* iv, size_t iv_size,
 	unsigned char* output, size_t * output_size) {
 	unsigned char arr2[256];

--- a/encrypt_src/functions.cc
+++ b/encrypt_src/functions.cc
@@ -7,7 +7,7 @@ using namespace std;
 using namespace v8;
 using namespace node;
 
-NAN_METHOD(encrypt) {
+NAN_METHOD(encryptMethod) {
     // Validate things
     if (info.Length() < 3) return;
     if (!info[2]->IsFunction()) return;
@@ -43,7 +43,7 @@ NAN_METHOD(encrypt) {
 
     // get our output len (could just do it here)
     size_t outputLen;
-    if (encrypt(input, (size_t)inputLen, iv, (size_t)ivLen, NULL, &outputLen) != 0) {
+    if (encryptMethod(input, (size_t)inputLen, iv, (size_t)ivLen, NULL, &outputLen) != 0) {
         delete input;
         delete iv;
         Local<Value> argv[1] = { Nan::New<String>("encrypt validation failed (iv length must be 32)").ToLocalChecked() };
@@ -53,7 +53,7 @@ NAN_METHOD(encrypt) {
 
     // encrypt
     unsigned char* output = new unsigned char[outputLen];
-    int code = encrypt(input, (size_t)inputLen, iv, (size_t)ivLen, output, &outputLen);
+    int code = encryptMethod(input, (size_t)inputLen, iv, (size_t)ivLen, output, &outputLen);
 
     delete input;
     delete iv;

--- a/encrypt_src/functions.h
+++ b/encrypt_src/functions.h
@@ -3,8 +3,8 @@
 
 #include <nan.h>
 
-extern "C" int encrypt(const unsigned char *input, size_t input_size, const unsigned char* iv, size_t iv_size, unsigned char* output, size_t * output_size);
+extern "C" int encryptMethod(const unsigned char *input, size_t input_size, const unsigned char* iv, size_t iv_size, unsigned char* output, size_t * output_size);
 
-NAN_METHOD(encrypt);
+NAN_METHOD(encryptMethod);
 
 #endif


### PR DESCRIPTION
…declaration error while compiling on macOS -> void encrypt(char *, int) __DARWIN_ALIAS(encrypt);

```
In file included from ../encrypt_src/NativeExtension.cc:1:
../encrypt_src/functions.h:6:16: error: functions that differ only in their return type cannot be overloaded
extern "C" int encrypt(const unsigned char *input, size_t input_size, const unsigned char* iv, size_t iv_size, unsigned char* output, size_t * output_size);
           ~~~ ^
/usr/include/unistd.h:549:7: note: previous declaration is here
void     encrypt(char *, int) __DARWIN_ALIAS(encrypt);
~~~~     ^
1 error generated.

```
