### PR TITLE
Handle the `error` event of http.request

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,6 +174,9 @@ Utils.prototype.hashWithServer = function(authTicket, latitude, longitude, accur
                 }
             })
         });
+        req.on("error", err => {
+            fail(err);
+        });
         req.write(requestData);
         req.end();
     });


### PR DESCRIPTION
This change prevents the app from throwing an error when the connection to the hashing server is interrupted. Instead it rejects the returned promise which can be handled by the caller.